### PR TITLE
Add Macro Dictionary to language server

### DIFF
--- a/mfdls/server.py
+++ b/mfdls/server.py
@@ -32,6 +32,7 @@ class MEDFORDLanguageServer(LanguageServer):
     """
 
     def __init__(self):
+        self.macros = {}
         super().__init__()
 
 
@@ -70,7 +71,11 @@ def _generate_syntactic_diagnostics(
     doc = ls.workspace.get_document(params.text_document.uri)
 
     # Get diagnostics on the document
-    (_, diagnostics) = validate_syntax(doc)
+    (details, diagnostics) = validate_syntax(doc)
 
     # Publish those diagnostics
-    ls.publish_diagnostics(doc.uri, diagnostics)
+    if diagnostics:
+        ls.publish_diagnostics(doc.uri, diagnostics)
+
+    if details:
+        ls.macros = details[0].macro_dictionary


### PR DESCRIPTION
At any time, the currently defined macros can be found at `ls.macros`. The dictionary is structured as follows:
```
{
    macro_name : (line_number, macro_text),
}
```
for example, with `testfiles/example.mfd`, we get
```
ls.macros = {
    "location": (32, "Bonney Lake"),
    "more": (20, "fun ames Hello World"),
    "theworldwillknow": (23, "what you did"),
    "thisisamacro": (21, "woah macros"),
    "whaosh": (22, "micor space hellooooo")
}
```